### PR TITLE
fix level formula

### DIFF
--- a/examples/demos/ViewFrustumCulling/OctreeNode.pde
+++ b/examples/demos/ViewFrustumCulling/OctreeNode.pde
@@ -12,7 +12,7 @@ class OctreeNode extends Node {
   }
 
   float level() {
-    return (log(1 / magnitude()) / log(2)) - 1;
+    return -log(magnitude()) / log(2) + 1;
   }
 
   @Override


### PR DESCRIPTION
We need a formula that meets:
If magnitude() is 1, level must be 1
If magnitude() is 0.5, level must be 2
If magnitude() is 0.25, level must be 3
....

The current formula is wrong :( 